### PR TITLE
Remove auto send and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ func main() {
 - Built-in HTTP status code handlers
 - Method validation helpers
 - Manual response control with `.Send()`
-- Thread-safe response building
 
 ## Missing Features?
 If you find any features missing or have suggestions for improvements, please feel free to open an issue or submit a pull request!

--- a/README.md
+++ b/README.md
@@ -4,42 +4,179 @@
 <img src="https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fa-z-animals.com%2Fmedia%2F2022%2F12%2Fshutterstock_171751469.jpg&f=1&nofb=1&ipt=8b0fc9d6b628d7a8cb0055ab417dab5ecc1c3d3ec632bc5cb6c52207a5a5ec3e" alt="GECHO Logo" width="400" height="400">
 
 ## Overview
-GECHO is a lightweight and easy-to-use response library designed to simplify the process of sending HTTP responses in Go web applications. It provides a set of helper functions to send JSON with ease.
+GECHO is a lightweight and easy-to-use response library designed to simplify the process of sending HTTP responses in Go web applications. It provides a fluent API for building JSON responses with automatic response handling.
 
 ## Installation
-To install GECHO, use the following command:
 ```bash
 go get -u github.com/MonkyMars/gecho
 ```
 
-## Usage
-Here's a simple example of how to use GECHO in your Go web application:
+## Response Structure
+All responses follow this JSON structure:
+```json
+{
+  "status": 200,
+  "success": true,
+  "message": "Success",
+  "data": {...},
+  "timestamp": "2024-01-01T12:00:00Z"
+}
+```
+
+## Fluent API
+
+### Building Responses
+- `NewOK(w)` - Creates a success response builder (status 200)
+- `NewErr(w)` - Creates an error response builder (status 500)
+
+Chain methods for customization:
+- `.WithMessage(string)` - Set response message
+- `.WithData(any)` - Set response data (ignored for errors)
+- `.WithStatus(int)` - Set HTTP status code
+- `.Send()` - Send the response (required)
+
+```go
+// Fluent API example
+gecho.NewOK(w).WithMessage("User created").WithData(user).WithStatus(http.StatusOK).Send()
+```
+
+## Success Functions
+
+### Success(w, data)
+Returns 200 OK with data and "Success" message.
+```go
+user := map[string]string{"name": "John"}
+gecho.Success(w).WithData(user).Send()
+```
+
+### Created(w, data)
+Returns 201 Created with data and "Resource Created" message.
+```go
+gecho.Created(w).WithData(newUser).Send()
+```
+
+## Client Error Functions
+
+### BadRequest(w)
+Returns 400 Bad Request with "Bad Request" message.
+```go
+gecho.BadRequest(w).Send()
+// Or customize: gecho.BadRequest(w).WithMessage("Invalid input").Send()
+```
+
+### Unauthorized(w)
+Returns 401 Unauthorized with "Unauthorized" message.
+```go
+gecho.Unauthorized(w).Send()
+```
+
+### Forbidden(w)
+Returns 403 Forbidden with "Forbidden" message.
+```go
+gecho.Forbidden(w).Send()
+```
+
+### NotFound(w)
+Returns 404 Not Found with "Not Found" message.
+```go
+gecho.NotFound(w).Send()
+```
+
+### MethodNotAllowed(w)
+Returns 405 Method Not Allowed with "Method Not Allowed" message.
+```go
+gecho.MethodNotAllowed(w).Send()
+```
+
+## Server Error Functions
+
+### InternalServerError(w)
+Returns 500 Internal Server Error with "Internal Server Error" message.
+```go
+gecho.InternalServerError(w).Send()
+```
+
+### ServiceUnavailable(w)
+Returns 503 Service Unavailable with "Service Unavailable" message.
+```go
+gecho.ServiceUnavailable(w).Send()
+```
+
+## Built-in Handlers
+
+### Method Validation
+Use `Handlers.HandleMethod()` to validate HTTP methods:
+```go
+func handler(w http.ResponseWriter, r *http.Request) {
+    if err := gecho.Handlers.HandleMethod(w, r, "POST"); err != nil {
+        err.Send() // Automatically sends 405 Method Not Allowed
+        return
+    }
+    // Handle POST request
+}
+```
+
+## Complete Example
 ```go
 package main
 
 import (
-	"net/http"
-	"github.com/MonkyMars/gecho"
+    "net/http"
+    "github.com/MonkyMars/gecho"
 )
 
-// Success
-func successHandler(w http.ResponseWriter, r *http.Request) {
-	response := map[string]string{"message": "Hello, GECHO!"}
-	gecho.Success(w, response).Send()
+func getUserHandler(w http.ResponseWriter, r *http.Request) {
+    // Method validation
+    if err := gecho.Handlers.HandleMethod(w, r, "GET"); err != nil {
+        err.Send()
+        return
+    }
+
+    user := map[string]interface{}{
+        "id":   1,
+        "name": "John Doe",
+        "email": "john@example.com",
+    }
+
+    gecho.Success(w).WithData(user).Send()
 }
 
-// Error
+func createUserHandler(w http.ResponseWriter, r *http.Request) {
+    if err := gecho.Handlers.HandleMethod(w, r, "POST"); err != nil {
+        err.Send()
+        return
+    }
+
+    // Validation logic here...
+    if validationFailed {
+        gecho.BadRequest(w).WithMessage("Invalid user data").Send()
+        return
+    }
+
+    newUser := map[string]interface{}{"id": 2, "name": "Jane Doe"}
+    gecho.Created(w).WithData(newUser).Send()
+}
+
 func errorHandler(w http.ResponseWriter, r *http.Request) {
-	gecho.Error(w, "An error occurred").Send()
+    gecho.InternalServerError(w).WithMessage("Something went wrong").Send()
 }
 
 func main() {
-	http.HandleFunc("/success", handler)
-	http.HandleFunc("/error", errorHandler)
-	http.ListenAndServe(":8080", nil)
+    http.HandleFunc("/user", getUserHandler)
+    http.HandleFunc("/user/create", createUserHandler)
+    http.HandleFunc("/error", errorHandler)
+    http.ListenAndServe(":8080", nil)
 }
 ```
 
+## Features
+- Fluent API for building responses
+- Automatic JSON marshaling
+- Consistent response structure
+- Built-in HTTP status code handlers
+- Method validation helpers
+- Manual response control with `.Send()`
+- Thread-safe response building
 
 ## Missing Features?
 If you find any features missing or have suggestions for improvements, please feel free to open an issue or submit a pull request!

--- a/gecho.go
+++ b/gecho.go
@@ -2,6 +2,7 @@ package gecho
 
 import (
 	"github.com/MonkyMars/gecho/errors"
+	"github.com/MonkyMars/gecho/handlers"
 	"github.com/MonkyMars/gecho/success"
 	"github.com/MonkyMars/gecho/utils"
 )
@@ -22,8 +23,8 @@ var InternalServerError = errors.InternalServerError
 var ServiceUnavailable = errors.ServiceUnavailable
 
 // Exported Success Functions
-var Success = success.Success[any]
-var Created = success.Created[any]
+var Success = success.Success
+var Created = success.Created
 
 // Exported built-in handlers
-var Handlers = errors.NewHandlers()
+var Handlers = handlers.NewHandlers()

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -1,9 +1,10 @@
-package errors
+package handlers
 
 import (
 	"fmt"
 	"net/http"
 
+	"github.com/MonkyMars/gecho/errors"
 	"github.com/MonkyMars/gecho/utils"
 )
 
@@ -16,7 +17,7 @@ func NewHandlers() *Handlers {
 func (h *Handlers) HandleMethod(w http.ResponseWriter, r *http.Request, intendedMethod string) *utils.ResponseBuilder {
 	method := r.Method
 	if method != intendedMethod {
-		return MethodNotAllowed(w).WithMessage(fmt.Sprintf("Method %s not allowed", method))
+		return errors.MethodNotAllowed(w).WithMessage(fmt.Sprintf("Method %s not allowed", method))
 	}
 
 	return nil

--- a/success/common.go
+++ b/success/common.go
@@ -8,18 +8,14 @@ import (
 
 // Success returns a ResponseBuilder for 200 OK responses
 // Use Send() to send the response with the default values
-func Success[T any](w http.ResponseWriter, data T) *utils.ResponseBuilder {
-	return utils.NewOK(w).WithStatus(http.StatusOK).
-		WithData(data).
-		WithMessage("Success")
+func Success(w http.ResponseWriter) *utils.ResponseBuilder {
+	return utils.NewOK(w).WithMessage("Success")
 }
 
 // Created returns a ResponseBuilder for 201 Created responses
 // Use Send() to send the response with the default values
-func Created[T any](w http.ResponseWriter, data T) *utils.ResponseBuilder {
-	return utils.NewOK(w).WithStatus(http.StatusCreated).
-		WithData(data).
-		WithMessage("Resource Created")
+func Created(w http.ResponseWriter) *utils.ResponseBuilder {
+	return utils.NewOK(w).WithMessage("Resource Created")
 }
 
 // Accepted returns a ResponseBuilder for 202 Accepted responses

--- a/success/common.go
+++ b/success/common.go
@@ -15,7 +15,7 @@ func Success(w http.ResponseWriter) *utils.ResponseBuilder {
 // Created returns a ResponseBuilder for 201 Created responses
 // Use Send() to send the response with the default values
 func Created(w http.ResponseWriter) *utils.ResponseBuilder {
-	return utils.NewOK(w).WithMessage("Resource Created")
+	return utils.NewOK(w).WithStatus(http.StatusCreated).WithMessage("Resource Created")
 }
 
 // Accepted returns a ResponseBuilder for 202 Accepted responses

--- a/utils/response.go
+++ b/utils/response.go
@@ -2,8 +2,6 @@ package utils
 
 import (
 	"net/http"
-	"runtime"
-	"sync"
 )
 
 // ResponseBuilder provides a fluent interface for building responses
@@ -11,30 +9,26 @@ type ResponseBuilder struct {
 	w        http.ResponseWriter
 	response *NewResponse
 	isError  bool
-	sent     bool
-	mu       sync.Mutex
 }
 
 // NewOK creates a new ResponseBuilder for success responses
 func NewOK(w http.ResponseWriter) *ResponseBuilder {
-	rb := newResponseBuilder(w, http.StatusOK, false)
-	return rb
+	return newResponseBuilder(w, http.StatusOK, false)
 }
 
 // NewErr creates a new ResponseBuilder for error responses
 func NewErr(w http.ResponseWriter) *ResponseBuilder {
-	rb := newResponseBuilder(w, http.StatusInternalServerError, true)
-	return rb
+	return newResponseBuilder(w, http.StatusInternalServerError, true)
 }
 
-// NewResponseBuilder creates a ResponseBuilder with custom status and type
+// newResponseBuilder creates a ResponseBuilder with custom status and type
 func newResponseBuilder(w http.ResponseWriter, status int, isError bool) *ResponseBuilder {
 	success := SUCCESS
 	if isError {
 		success = FAILURE
 	}
 
-	rb := &ResponseBuilder{
+	return &ResponseBuilder{
 		w: w,
 		response: &NewResponse{
 			Status:    status,
@@ -43,11 +37,9 @@ func newResponseBuilder(w http.ResponseWriter, status int, isError bool) *Respon
 		},
 		isError: isError,
 	}
-	runtime.SetFinalizer(rb, (*ResponseBuilder).finalize)
-	return rb
 }
 
-// WithMessage sets the response message and auto-sends
+// WithMessage sets the response message and returns builder for chaining
 func (rb *ResponseBuilder) WithMessage(message string) *ResponseBuilder {
 	rb.response.Message = message
 	return rb
@@ -69,34 +61,12 @@ func (rb *ResponseBuilder) WithStatus(status int) *ResponseBuilder {
 
 // Send manually sends the response
 func (rb *ResponseBuilder) Send() error {
-	rb.mu.Lock()
-	defer rb.mu.Unlock()
-
-	if rb.sent {
-		return nil
-	}
-
 	data := rb.response.Data
+
 	if rb.isError {
 		data = nil
 	}
 
 	err := writeJSON(rb.w, rb.response.Status, rb.response.Success, rb.response.Message, data)
-	rb.sent = true
-	runtime.SetFinalizer(rb, nil) // Clear finalizer since we've sent
 	return err
-}
-
-func (rb *ResponseBuilder) finalize() {
-	rb.mu.Lock()
-	defer rb.mu.Unlock()
-
-	if !rb.sent {
-		data := rb.response.Data
-		if rb.isError {
-			data = nil
-		}
-		_ = writeJSON(rb.w, rb.response.Status, rb.response.Success, rb.response.Message, data)
-		rb.sent = true
-	}
 }


### PR DESCRIPTION
This pull request refactors the GECHO library to provide a more consistent and fluent API for building HTTP responses in Go web applications. The changes include improvements to the response builder interface, updated documentation, and better separation of concerns for built-in handlers. The API is now easier to use, with clear chaining methods and automatic JSON response formatting, and the documentation has been rewritten to reflect these updates.

**API and Documentation Improvements**

* The `README.md` has been extensively rewritten to showcase the new fluent API, consistent JSON response structure, and usage examples for success, error, and built-in handler functions. It also introduces method validation helpers and highlights new features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R119) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R179)

**Response Builder Refactoring**

* The `ResponseBuilder` interface in `utils/response.go` has been simplified: thread-safety and finalization logic have been removed, making the builder easier to use with explicit `.Send()` calls and chainable methods. [[1]](diffhunk://#diff-d712335d4ea7486e30053b8461e6011d7f7efce6f3dc9bda18f1a2772896bcdeL5-R31) [[2]](diffhunk://#diff-d712335d4ea7486e30053b8461e6011d7f7efce6f3dc9bda18f1a2772896bcdeL46-R42) [[3]](diffhunk://#diff-d712335d4ea7486e30053b8461e6011d7f7efce6f3dc9bda18f1a2772896bcdeL72-L102)
* The `.WithMessage`, `.WithStatus`, and `.WithData` methods now support chaining, and `.Send()` must be called manually to send the response. [[1]](diffhunk://#diff-d712335d4ea7486e30053b8461e6011d7f7efce6f3dc9bda18f1a2772896bcdeL46-R42) [[2]](diffhunk://#diff-d712335d4ea7486e30053b8461e6011d7f7efce6f3dc9bda18f1a2772896bcdeL72-L102)

**Success and Error Function Updates**

* The generic success and created functions have been replaced with non-generic versions that return a `ResponseBuilder` for chaining, aligning with the new API style.
* The exported handler functions in `gecho.go` are updated to use the new handlers package and the revised success functions. [[1]](diffhunk://#diff-1f7928094f23f2d043e041ab8ec67feb423ac5c1fd21b72d2a222285054b7b5cR5) [[2]](diffhunk://#diff-1f7928094f23f2d043e041ab8ec67feb423ac5c1fd21b72d2a222285054b7b5cL25-R30)

**Separation of Built-in Handlers**

* Built-in HTTP method validation handlers have been moved from the `errors` package to a new `handlers` package for better separation of concerns. The method validation logic now returns a response builder for errors. [[1]](diffhunk://#diff-68b76b182c0228d7f26015e36399128c4d78d163d6eedefc61deb16b213f86b0L1-R7) [[2]](diffhunk://#diff-68b76b182c0228d7f26015e36399128c4d78d163d6eedefc61deb16b213f86b0L19-R20)